### PR TITLE
Add missing value to switch statement

### DIFF
--- a/src/CST816Touch.cpp
+++ b/src/CST816Touch.cpp
@@ -268,6 +268,7 @@ void CST816Touch::handleTouch() {
 	if (iGestureId > 0) {
 		gesture_t eGesture((gesture_t)iGestureId);
 		switch (eGesture) {
+			case GESTURE_NONE:			return "NONE";
 			case GESTURE_LEFT:			return "LEFT";
 			case GESTURE_RIGHT:			return "RIGHT";
 			case GESTURE_UP:			return "UP";


### PR DESCRIPTION
This little PR removes a warning (which becomes fatal when compiling with -Werror=all such as in the latest versions of the ESP32 core).
Thank you for this great lib!