### PR TITLE
introduced begin instead of init

### DIFF
--- a/examples/example_gesture_only/example_gesture_only.ino
+++ b/examples/example_gesture_only/example_gesture_only.ino
@@ -3,7 +3,9 @@
 
 #include "TouchSubscriber.h"
 
-#define PIN_TFT_POWER_ON                 15
+#define PIN_TFT_POWER_ON	15
+#define I2C_SDA				18
+#define I2C_SCL				17
 
 using namespace MDO;
 
@@ -15,10 +17,12 @@ void setup () {
 
     pinMode(PIN_TFT_POWER_ON, OUTPUT);				//TFT poweron
     digitalWrite(PIN_TFT_POWER_ON, HIGH);	
-	
-	if (oTouch.init(Wire, &oTouchSubriber)) {
+
+	Wire.begin(I2C_SDA, I2C_SCL);
+	Wire.setClock(400000);	//For reliable communication, it is recommended to use a *maximum* communication rate of 400Kbps	
+
+	if (oTouch.begin(Wire, &oTouchSubriber)) {
 		Serial.println("Touch screen initialization done");
-		//oTouch.setNotificationsOnAllEvents();	//in case touch and release events are desired, comment out for touch-release events only
 	} else {
 		Serial.println("Touch screen initialization failed..");
 	}

--- a/examples/example_interrupt/example_interrupt.ino
+++ b/examples/example_interrupt/example_interrupt.ino
@@ -1,7 +1,9 @@
 #include <Wire.h>
 #include <CST816_TouchLib.h>
 
-#define PIN_TFT_POWER_ON                 15
+#define PIN_TFT_POWER_ON	15
+#define I2C_SDA				18
+#define I2C_SCL				17
 
 using namespace MDO;
 
@@ -12,9 +14,12 @@ void setup () {
 	Serial.begin(115200);				//so that DummyTouchSubscriber can use that to report
 
     pinMode(PIN_TFT_POWER_ON, OUTPUT);				//TFT poweron
-    digitalWrite(PIN_TFT_POWER_ON, HIGH);	
+    digitalWrite(PIN_TFT_POWER_ON, HIGH);
 	
-	if (oTouch.init(Wire, &oTouchSubriber)) {
+	Wire.begin(I2C_SDA, I2C_SCL);
+	Wire.setClock(400000);	//For reliable communication, it is recommended to use a *maximum* communication rate of 400Kbps	
+	
+	if (oTouch.begin(Wire, &oTouchSubriber)) {
 		//oTouch.setNotificationsOnAllEvents();	//in case touch and release events are desired, comment out for touch-release events only
 		Serial.println("Touch screen initialization done");
 	} else {

--- a/examples/example_no_callback/example_no_callback.ino
+++ b/examples/example_no_callback/example_no_callback.ino
@@ -1,7 +1,9 @@
 #include <Wire.h>
 #include <CST816_TouchLib.h>
 
-#define PIN_TFT_POWER_ON                 15
+#define PIN_TFT_POWER_ON	15
+#define I2C_SDA				18
+#define I2C_SCL				17
 
 using namespace MDO;
 
@@ -13,7 +15,10 @@ void setup () {
 	pinMode(PIN_TFT_POWER_ON, OUTPUT);				//TFT poweron
 	digitalWrite(PIN_TFT_POWER_ON, HIGH);	
 
-	if (oTouch.init(Wire, 0)) {
+	Wire.begin(I2C_SDA, I2C_SCL);
+	Wire.setClock(400000);	//For reliable communication, it is recommended to use a *maximum* communication rate of 400Kbps
+
+	if (oTouch.begin(Wire)) {
 		Serial.println("Touch screen initialization done");
 	} else {
 		Serial.println("Touch screen initialization failed..");

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CST816_TouchLib
-version=0.7
+version=0.8
 author=MDO
 maintainer=MDO
 sentence=A CST816 touch and gesture library, tested using the LilyGO T-Display ESP32-S3. Includes gestures.

--- a/src/CST816Touch.cpp
+++ b/src/CST816Touch.cpp
@@ -4,7 +4,6 @@
 //if you like, enable this for debug serial messages
 //I tried this from the INO file, but could not get that to work..
 //#define CST816_TOUCH_LIB_DEBUG
-//#include <mdomisc.h>
 
 //avoid the defines, as per https://docs.arduino.cc/learn/contributions/arduino-writing-style-guide#variables
 const uint8_t TOUCH_CMD_SLEEP 			= 0x03;
@@ -543,7 +542,8 @@ void CST816Touch::setNotificationsOnReleaseOnly() {
 
 
 /**
- * Initialize: this is a mandatory call to be made 
+ * Initialize: this is a mandatory call to be made
+ * @deprecated, since this initializes Wire and it's not the Ardunio recommended name
  * For each PIN which this class should not use / change: set to -1
  * The interrupt pin is mandatory for proper usage.
  * return false on issues
@@ -554,14 +554,31 @@ bool CST816Touch::init(TwoWire& w, TouchSubscriberInterface* pTouchSubscriber /*
 							int I2C_SCL /*= 17*/, 
 							uint8_t CTS816S_I2C_ADDRESS /*= 0x15*/, 							
 							int PIN_RESET /*= 21*/) {	//note that this is a mandatory PIN, so don't set this to -1
-	m_pI2C = &w;
-	bool bOk = false;
-	if (m_pI2C != 0) {
+	
+	bool bOk = begin(w, pTouchSubscriber, PIN_INTERRUPT, CTS816S_I2C_ADDRESS, PIN_RESET);
+
+	if ((bOk) && (m_pI2C != 0)) {
 		m_pI2C->begin(I2C_SDA, I2C_SCL);
-		m_pI2C->setClock(400000);	//For reliable communication, it is recommended to use a maximum communication rate of 400Kbps
-		bOk = true;		
+		m_pI2C->setClock(400000);	//For reliable communication, it is recommended to use a maximum communication rate of 400Kbps	
 	}
-		
+
+	return bOk;
+}
+
+/**
+ * begin: this is a mandatory call to be made.
+ * Please ensure that Wire has been initialized before this call, using the begin method
+ * For each PIN which this class should not use / change: set to -1
+ * The interrupt pin is mandatory for proper usage.
+ * return false on issues
+ */
+bool CST816Touch::begin(TwoWire& w, TouchSubscriberInterface* pTouchSubscriber /*= 0*/, 
+							int PIN_INTERRUPT 			/*= 16 */, 
+							uint8_t CTS816S_I2C_ADDRESS /*= 0x15*/, 							
+							int PIN_RESET 				/*= 21*/) {	//note that this is a mandatory PIN, so don't set this to -1
+	m_pI2C = &w;
+	bool bOk = m_pI2C != 0;
+	
 	m_ucAddress = CTS816S_I2C_ADDRESS;
 	m_iPIN_RESET = PIN_RESET;
 	m_iPIN_INTERRUPT = PIN_INTERRUPT;
@@ -605,7 +622,6 @@ bool CST816Touch::init(TwoWire& w, TouchSubscriberInterface* pTouchSubscriber /*
 
 	return bOk;
 }
-		
 
 CST816Touch::CST816Touch() {
 	m_pI2C = 0;

--- a/src/CST816Touch.h
+++ b/src/CST816Touch.h
@@ -84,10 +84,18 @@ class CST816Touch {
 		void			setNotificationsOnReleaseOnly();	//get notifications on release event only - this is the default
 		
 		/**
-		 * init. For each PIN which this class should not [use / change]: set to -1
+		 * initialize. For each PIN which this class should not [use / change]: set to -1
+		 * @deprecated, based on the Wire initialization, which does not belong in a library..
+		 * WILL initialize Wire. Use 'begin' if this is not desired
 		 * return false on issues
 		 */
 		bool			init(TwoWire& w, TouchSubscriberInterface* pTouchSubscriber = 0, int PIN_INTERRUPT = 16, int I2C_SDA = 18, int I2C_SCL = 17, uint8_t CTS816S_I2C_ADDRESS = 0x15, int PIN_RESET = 21);
+		
+		/**
+		 * begin / initialize this class/library
+		 * return false on issues
+		 */
+		bool			begin(TwoWire& w, TouchSubscriberInterface* pTouchSubscriber = 0, int PIN_INTERRUPT = 16, uint8_t CTS816S_I2C_ADDRESS = 0x15, int PIN_RESET = 21);
 
 	
 		CST816Touch();


### PR DESCRIPTION
deprecated init
introduced begin, with the goal of not initializing Wire in this library