### PR TITLE
added hardware double click support and added movement notifications in 'fast mode' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CST816 touchscreen Arduino Library 
 This is a library for the touch part of the *LILYGO T-Display ESP32-S3* product.
-I'm not in any way linked to LILYGO, but I liked the physical product. Unfurtunately, the Arduino library support for the touch part could / should be improved. 
+I'm not in any way linked to LILYGO, but I liked the physical product. Unfortunately, the Arduino library support for the touch part could / should be improved. 
 Specifically the lack of gesture support (which the hardware does support): This library fixes that.
 
 Gesture types supported: RIGHT, LEFT, DOWN, UP, TOUCH_BUTTON, DOUBLE_CLICK, LONG_PRESS.
@@ -12,9 +12,34 @@ I didn't test other CST816-based products, but I guess that these should work as
 
 There are two main ways of interfacing:
  * The easy way without any callbacks or so: please see example_no_callback
- * My preferred way using a callback mechanism based on an interface class: please see example_gesture_only
+ * My preferred way using a callback mechanism based on an interface class: please see example_interrupt
 
-I managed to get a sleep working (alowing the esp32 to wake up from deep sleep after), please see example_gesture_only for that.
+An ESP32 deep sleep is also possible with a touch-based wakeup, please see example_gesture_only for that.
+For the CST816 sleep to work, it needs to be on when the command is issue, the above example shows that as well.
+Note: when using this example, ensure the screen is touched just before the a new program is flashed, to ensure that the ESP32-S3 is awake. 
 
-Note that all was created without official documentation. The documents I could find do not provide any info on registers, exact timing, etc.
-If someone could point me to that, this library can most likely be improved (a lot)..
+This library was created without official documentation. The documents I could find do not provide any info on registers, exact timing, etc.
+If someone could point me to that, this library can most likely be improved..
+
+## Usage
+Typically, start with the method *begin*
+Standard options are:
+ - setOperatingModeFast, this is the quickest option with most options and supporting all gestures. The double click gesture however **will** give two touch events as well. This is the current default mode.
+ - setOperatingModeHardwareBased, in which case all gestures are executed in hardware. For both long press and double click, this is the slowest option
+
+And in *loop*, call *control* regularly: see the examples.
+
+Note that by default the chip goes in a standby/sleep mode (which it leaves on touch).
+In such a standby/sleep save mode, it will **not respond to a command**.
+When the program only interacts with the CST816 chip during initialization, or based on a touch: this scenario will happen.
+If it does, the chip can be reset using *resetChip*, that will however ensure that the chip loses state (it's settings). Set bRestoreState to true when this needs to be restored.
+It's an option to use *setAutoSleep* to false, making sure this standby/sleep mode won't be entered, but that seems like a waste of power to me.
+
+## Options
+- *getDeviceType*, check the type of CST816 chip
+- *getFirmwareVersion*, check the firmware version
+- *sleep*, might be useful when *setAutoSleep* has been set to false
+- *resetChip*, used to ensure that the chip in auto-sleep-mode is ready to receive commands (don't forget bRestoreState in this case)
+-
+- *setNotificationsOnAllEvents* and *setNotificationsOnReleaseOnly* can be used to either get all events (touch and release) or not
+- *setNotifyOnMovement* can be used to get movement gesture updates, the interval of which can be set using *setMovementInterval*

--- a/examples/example_gesture_only/example_gesture_only.ino
+++ b/examples/example_gesture_only/example_gesture_only.ino
@@ -21,27 +21,49 @@ void setup () {
 	Wire.begin(I2C_SDA, I2C_SCL);
 	Wire.setClock(400000);	//For reliable communication, it is recommended to use a *maximum* communication rate of 400Kbps	
 
-	if (oTouch.begin(Wire, &oTouchSubriber)) {
-		Serial.println("Touch screen initialization done");
-	} else {
+	if (!oTouch.begin(Wire, &oTouchSubriber)) {
 		Serial.println("Touch screen initialization failed..");
+		while(true){
+			delay(100);
+		}
 	}
+
+	CST816Touch::device_type_t eDeviceType;
+	if (oTouch.getDeviceType(eDeviceType)) {
+		Serial.print("Device is of type: ");
+		Serial.println(CST816Touch::deviceTypeToString(eDeviceType));
+	}
+		
+	Serial.println("Touch screen initialization done");
+}
+
+bool sleepScreenAndESP32() {
+	if (!oTouch.sleep()) {
+		return false;
+	}
+	Serial.println("Touch screen is asleep, now for the controller itself");
+	Serial.println("Touch the screen to wake up");
+	delay(100);
+	esp_deep_sleep_start();	//will wake on touch, this being an ESP32 that will result in a setup() again
+	
+	return true;	//note that this line will never-ever be executed
 }
 
 void loop () {
 	
 	unsigned long ulStart = millis();
-	while(millis() - ulStart < 20000) {	//Handle gestures for 20 seconds, just for demo
+	while(millis() - ulStart < 45000) {	//Handle gestures for 45 seconds, just for demo
 		oTouch.control();
 	}
 	
 	//followed by a deep sleep
-	if (oTouch.sleep()) {
-		Serial.println("Touch screen is asleep, now for the controller itself");
-		Serial.println("Touch the screen to wake up");
-		delay(100);
-		esp_deep_sleep_start();	//will wake on touch, this being an ESP32 that will result in a setup() again
-	} else {
-		Serial.println("Initiate a sleep failed");
+	if (!sleepScreenAndESP32()) {
+		Serial.println("Initiate a sleep failed, the touch chip was most likely sleeping");
+		if (oTouch.resetChip(true)) {
+			Serial.println("Yes, most likely. The chip is awake and state is restored by now");
+			if (!sleepScreenAndESP32()) {
+				Serial.println("Initiate a sleep failed permanently..");
+			}
+		}
 	}
 }

--- a/examples/example_interrupt/example_interrupt.ino
+++ b/examples/example_interrupt/example_interrupt.ino
@@ -19,12 +19,36 @@ void setup () {
 	Wire.begin(I2C_SDA, I2C_SCL);
 	Wire.setClock(400000);	//For reliable communication, it is recommended to use a *maximum* communication rate of 400Kbps	
 	
-	if (oTouch.begin(Wire, &oTouchSubriber)) {
-		//oTouch.setNotificationsOnAllEvents();	//in case touch and release events are desired, comment out for touch-release events only
-		Serial.println("Touch screen initialization done");
-	} else {
+	if (!oTouch.begin(Wire, &oTouchSubriber)) {
 		Serial.println("Touch screen initialization failed..");
+		while(true){
+			delay(100);
+		}
 	}
+	
+//	if (!oTouch.setOperatingModeHardwareBased()) {
+//		Serial.println("Set full hardware operational mode failed");
+//	}
+
+//	if (oTouch.setNotifyOnMovement()) {
+//		oTouch.setMovementInterval(100);	//as example: limit to 10 per second (so 100 msec as interval)
+//	} else {
+//		//only available in 'fast'-mode
+//		Serial.println("Set notify on movement failed");
+//	}
+	
+//	if (!oTouch.setNotificationsOnAllEvents()) {
+//		//only available in 'fast'-mode, provides events on touch and release of the screen
+//		Serial.println("Set notify on touch-and-release failed");
+//	}
+
+	CST816Touch::device_type_t eDeviceType;
+	if (oTouch.getDeviceType(eDeviceType)) {
+		Serial.print("Device is of type: ");
+		Serial.println(CST816Touch::deviceTypeToString(eDeviceType));
+	}
+		
+	Serial.println("Touch screen initialization done");
 }
 
 void loop () {

--- a/examples/example_no_callback/example_no_callback.ino
+++ b/examples/example_no_callback/example_no_callback.ino
@@ -18,12 +18,33 @@ void setup () {
 	Wire.begin(I2C_SDA, I2C_SCL);
 	Wire.setClock(400000);	//For reliable communication, it is recommended to use a *maximum* communication rate of 400Kbps
 
-	if (oTouch.begin(Wire)) {
-		Serial.println("Touch screen initialization done");
-	} else {
+	if (!oTouch.begin(Wire)) {
 		Serial.println("Touch screen initialization failed..");
+		while(true){
+			delay(100);
+		}
 	}
+
+	if (!oTouch.setOperatingModeHardwareBased()) {
+		Serial.println("Set full hardware operational mode failed");
+	}
+
+//	if (oTouch.setNotifyOnMovement()) {
+//		oTouch.setMovementInterval(100);	//as example: limit to 10 per second (so 100 msec as interval)
+//	} else {
+//		//only available in 'fast'-mode
+//		Serial.println("Set notify on movement failed");
+//	}
+			
+	CST816Touch::device_type_t eDeviceType;
+	if (oTouch.getDeviceType(eDeviceType)) {
+		Serial.print("Device is of type: ");
+		Serial.println(CST816Touch::deviceTypeToString(eDeviceType));
+	}
+		
+	Serial.println("Touch screen initialization done");
 }
+
 
 void loop () {
 	oTouch.control();

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CST816_TouchLib
-version=0.8
+version=1.0
 author=MDO
 maintainer=MDO
 sentence=A CST816 touch and gesture library, tested using the LilyGO T-Display ESP32-S3. Includes gestures.

--- a/src/CST816Touch.h
+++ b/src/CST816Touch.h
@@ -19,38 +19,61 @@ class CST816Touch {
 	
 	public:	//types
 		
+		enum touch_t {
+			TOUCH_DOWN      = 0,			//Touch press
+			TOUCH_UP        = 1,			//Touch release
+			TOUCH_CONTACT   = 2				//Touch contact
+		};
+
 		enum gesture_t {					//when updating, don't forget the GestureIdToString method..
 			GESTURE_NONE = 0,
 			GESTURE_RIGHT,
 			GESTURE_LEFT,
 			GESTURE_DOWN,
 			GESTURE_UP,
-			GESTURE_TOUCH_BUTTON = 5,
-			GESTURE_DOUBLE_CLICK,			//software determined, the hardware reported evenet seems absent
-			//GESTURE_DOUBLE_CLICK = 0x0B,	//commented out, since it never happens on my LILYGO T-Display ESP32-S3's
+			GESTURE_TOUCH_BUTTON = 5,		// or 'single click'
+			GESTURE_DOUBLE_CLICK = 0x0B,	//depending on the operational mode, this might be software determined
 			GESTURE_LONG_PRESS = 0x0C
+		};
+		
+		enum device_type_t {
+			DEVICE_UNKNOWN,
+			DEVICE_CST716	= 0x20,
+			DEVICE_CST816S	= 0xB4,
+			DEVICE_CST816T	= 0xB5,
+			DEVICE_CST816D	= 0xB6
+		};
+		
+		enum touch_opering_mode_t {
+			TOUCH_MODE_FAST,			//quickest mode, double click and long press are software based, double click triggers 2 touch events AND a gesture event
+			TOUCH_MODE_HARDWARE			//all fully executed in hardware, long press takes a lot longer, double click however only gives a single gesture event
 		};
 		
 	private:
 		TwoWire*					m_pI2C;		
+		bool						m_bWeInitializedI2C;
 		int							m_iPIN_RESET;
 		int 						m_iPIN_INTERRUPT;
 		uint8_t						m_uiCTS816S_I2C_ADDRESS;	
 		uint8_t						m_ucAddress;
 		uint8_t						m_ucBuffer[CST816_TOUCH_BUF_SIZE];
-		uint8_t						m_ucPrevousBuffer[CST816_TOUCH_BUF_SIZE];
+		uint8_t						m_ucPreviousBuffer[CST816_TOUCH_BUF_SIZE];
 		TouchSubscriberInterface*	m_pTouchSubscriber;
 		
-		unsigned long				m_ulLastGesture;	//when   - GESTURE
-		gesture_t					m_eLastGesture;		//what
-		int							m_iLastGestureX;	//where
-		int							m_iLastGestureY;	//where
-		
-		unsigned long				m_ulLastTouch;		//when   - this is the last release of a touch, used to check double click
-		int							m_iLastTouchX;		//where
-		int							m_iLastTouchY;		//where
-		
+		touch_opering_mode_t		m_eOperatingMode;
 		bool						m_bNotifyReleaseOnly;
+		bool						m_bNotifyMotion;
+		unsigned long				m_ulMovementInterval;	//the minimal time (in msec) which should have passed before a new gesture-movement is reported. defaults to 50
+		
+		unsigned long				m_ulLastGestureTime;	//when   - GESTURE
+		gesture_t					m_eLastGesture;			//what
+		int							m_iLastGestureX;		//where
+		int							m_iLastGestureY;		//where
+		
+		unsigned long				m_ulLastTouchTime;		//when   - this is the last release of a touch, used to check double click
+		int							m_iLastTouchX;			//where
+		int							m_iLastTouchY;			//where
+		
 		bool						m_bTouchConsumed;
 		bool						m_bGestureConsumed;
 	
@@ -60,29 +83,44 @@ class CST816Touch {
 		bool			parseTouchEvent(int& x, int& y, bool& currentlyPressed);
 		bool			writeRegister(uint8_t ucRegister, uint8_t ucByteToWrite);
 		bool			readRegister(uint8_t ucRegister, uint8_t iRequestedSize);
+
+		bool			setOperatingMode(touch_opering_mode_t eOperingMode, bool bNotifyMotion, bool bWakeChipFirst);
+		bool			printChipOperatingMode();
 		
 		bool			read();
 		bool			hadPhysicalEvent();	//touch or gesture.. Basically: anything to report?
+		bool			handleGesture(gesture_t eGesture, int x, int y, bool currentlyPressed);
 		bool			handleGesture();
 		bool			handleTouch();
 	
 	public:
+		static String	deviceTypeToString(device_type_t eDeviceType);
 		static String	gestureIdToString(int iGestureId);
 		void			getLastTouchPosition(int& x, int& y);
 		void			getLastGesture(gesture_t& gesture, int& x, int& y);
 		bool			hadTouch() const;
 		bool			hadGesture() const;
-		
-		bool			getFirmwareVersion(unsigned long& ulFW);
-		void			setChipInDynamicMode();	//ensuring it listens to our commands..
+
+		bool			setAutoSleep(bool bEnable);
+		bool			getDeviceType(device_type_t& eDeviceType);
+		bool			getFirmwareVersion(unsigned char& ucFW);
 		bool			sleep();
+		bool			resetChip(bool bRestoreState);	//ensuring it listens to our commands..
+		
 		void			printBuf(bool bWhenChangedOnly = false);	//just for debug purposes.
 		void			deInit();
+		void			stop();
 		bool			control();	//please call in loop()
 
-		void			setNotificationsOnAllEvents();		//get notifications on touch events and release event
-		void			setNotificationsOnReleaseOnly();	//get notifications on release event only - this is the default
+		void			setMovementInterval(unsigned long ulMovementInterval);	//sets the minimal time (in msec) which should have passed before a new gesture-movement is reported. defaults to 50
+		bool			setNotifyOnMovement(bool bMovementNotificationsRequired = true);
+
+		bool			setNotificationsOnAllEvents();		//get notifications on touch events and release event
+		void			setNotificationsOnReleaseOnly();	//get notifications on release event only - this is the *default*
 		
+		bool			setOperatingModeFast();				//set quickest operating mode, double click and long press are software based, double click triggers 2 touch events AND a gesture event - this is the *default*
+		bool			setOperatingModeHardwareBased();	//set full hardware based operating mode, long press takes a lot longer, double click however only gives a single gesture event 
+
 		/**
 		 * initialize. For each PIN which this class should not [use / change]: set to -1
 		 * @deprecated, based on the Wire initialization, which does not belong in a library..


### PR DESCRIPTION
Quite a major update:
-added hardware double click support
-in 'fast mode', added movement notifications

Doing so required a few interface changes, sorry for that.

renamed setChipInDynamicMode to resetChip, since that's actually what it is (after finding out that this resets the configured registers..)

Removed the bWakeChipFirst parameter from setAutoSleep, getDeviceType, getFirmwareVersion, sleep. Rationale: it's every slow and resets the chip state. That can be restored but that makes it even slower. Typically, these methods will be used either directly after a poweron, or as a result of a touch screen event anyhow and in both of these situations a reset is not needed.

added setMovementInterval, so that the time which should have passed before a new gesture-movement is reported can be set